### PR TITLE
Jm/odometry path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(message_filters REQUIRED)
 
 set(msg_files
   "msg/ObjectOdometry.msg"
+  "msg/ObjectOdometryPath.msg"
+  "msg/MultiObjectOdometryPath.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/msg/MultiObjectOdometryPath.msg
+++ b/msg/MultiObjectOdometryPath.msg
@@ -1,3 +1,6 @@
-std_msgs/Header header
+# Interface representing multiple object paths over time
+# header should be the current ROS time
 
+std_msgs/Header header
+# List of object odometry paths, one per object path segment
 ObjectOdometryPath[] paths

--- a/msg/MultiObjectOdometryPath.msg
+++ b/msg/MultiObjectOdometryPath.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+
+ObjectOdometryPath[] paths

--- a/msg/ObjectOdometry.msg
+++ b/msg/ObjectOdometry.msg
@@ -1,7 +1,14 @@
 # This represents the odometry (pose and velocity) of a single object with given id
+# We use the header from odom.header which should be the timestamp 
+# of the estimated motion/pose
 
+# object pose (L_w_k) and body-centric velocity.
 nav_msgs/Odometry odom
+# motion in world from k-1 to k
+geometry_msgs/PoseWithCovariance h_w_km1_k
+# unique object id (j)
 int64 object_id
-
-# Colour for visualisation. Can be unused.
-std_msgs/ColorRGBA colour
+# sequence ID: consecutively increasing ID (k)
+# Sequence id's can be used to indicate when odometries are missing
+# as they will be out of order (but should always be increasing)
+uint32 sequence 

--- a/msg/ObjectOdometryPath.msg
+++ b/msg/ObjectOdometryPath.msg
@@ -1,4 +1,7 @@
 std_msgs/Header header
 std_msgs/ColorRGBA colour
 int64 object_id
+# indicating which segment of the total object trajectory this message 
+# corresponds to. A single object(id) may have multiple segments
+int64 path_segment 0
 ObjectOdometry[] object_odometries

--- a/msg/ObjectOdometryPath.msg
+++ b/msg/ObjectOdometryPath.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+std_msgs/ColorRGBA colour
+int64 object_id
+ObjectOdometry[] object_odometries


### PR DESCRIPTION
- split ObjectOdom messages into pure odometry and path messages
- odom no-longer contains misc information needed for visualisation only (e.g. colour) as this is inside the odometry path message
- multi object odom path messages introduced